### PR TITLE
Add auto-highlight for `Int[ ]`

### DIFF
--- a/Rubi/Rubi.m
+++ b/Rubi/Rubi.m
@@ -94,6 +94,8 @@ ClearStatusBar[] := If[$Notebooks, CurrentValue[EvaluationNotebook[], WindowStat
 
 
 Unprotect[Int];  Clear[Int];  Clear[Unintegrable];  Clear[CannotIntegrate];
+(*auto-highlighting for Int[]*)
+SyntaxInformation[Int] = {"LocalVariables" -> {"Integrate", {2, 2}}}; 
 
 (* The order of loading the rule-files below is crucial to ensure a functional Rubi integrator! *)
 LoadRules[$utilityPackage];


### PR DESCRIPTION
I propose to highlight `Int[ ]` with the official [`SyntaxInformation[ ]`](https://reference.wolfram.com/language/ref/SyntaxInformation.html); if any side-effects are known, this PR shall not be accepted.